### PR TITLE
add django-extensions and werkzeug

### DIFF
--- a/escalate/escalate/settings/base.py
+++ b/escalate/escalate/settings/base.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'rest_api',
     'crispy_forms',
     'rest_framework_swagger',
+    'django_extensions'
 ]
 
 MIDDLEWARE = [

--- a/escalate/requirements.txt
+++ b/escalate/requirements.txt
@@ -15,4 +15,5 @@ uritemplate
 coreapi
 django-url-filter
 django-rest-swagger
+django-extensions==3.0.5
 coreschema

--- a/escalate/requirements_developer.txt
+++ b/escalate/requirements_developer.txt
@@ -1,2 +1,3 @@
 pytest-django
 beautifulsoup4
+werkzeug==1.0.1


### PR DESCRIPTION
The primary motivation for this is to be able to log the SQL that Django generates baed on API calls. 

This can be accomplished with `python manage.py runserver_plus --print-sql` (or in the shell with python manage.py shell_plus --print-sql`)