### PR TITLE
added csv export button for lists

### DIFF
--- a/escalate/core/templates/core/generic/list.html
+++ b/escalate/core/templates/core/generic/list.html
@@ -13,6 +13,13 @@
 
 {% block content %}
 <div class="container">
+  <div class="export-buttons-container">
+    {% for export_type, export_url in export_urls.items%}
+      <button>
+        <a href="{{export_url}}" style="color:black;">{{export_type}}</a>
+      </button>
+    {% endfor %}
+  </div>
   <form method="post">{% csrf_token %}
     <div class="table-responsive text-nowrap">
       <table class="table table-bordered table-hover">

--- a/escalate/core/urls.py
+++ b/escalate/core/urls.py
@@ -8,6 +8,7 @@ from .views.experiment import CreateExperimentView, ExperimentDetailView, Experi
 from core.utilities.utils import view_names, camel_to_snake
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.views.generic.base import RedirectView
+import core.views.exports.file_types as export_file_types
 
 urlpatterns = [
     path('', LoginView.as_view(), name='login'),
@@ -29,9 +30,8 @@ urlpatterns = [
 
 
 def add_urls(model_name, pattern_list):
-
-    lower_case_model_name = camel_to_snake(model_name)
-    new_urls = [path(f'{lower_case_model_name}_list/',
+     lower_case_model_name = camel_to_snake(model_name)
+     new_urls = [path(f'{lower_case_model_name}_list/',
                      getattr(core.views, f'{model_name}List').as_view(),
                      name=f'{lower_case_model_name}_list'),
                 path(f'{lower_case_model_name}/',
@@ -47,7 +47,13 @@ def add_urls(model_name, pattern_list):
                      getattr(core.views, f'{model_name}View').as_view(),
                      name=f'{lower_case_model_name}_view'),
                 ]
-    return pattern_list + new_urls
+     export_urls = [
+                    path(f'{lower_case_model_name}_export_{file_type}/',
+                    getattr(core.views, f'{model_name}Export{file_type.capitalize()}').as_view(),
+                    name=f'{lower_case_model_name}_export_{file_type}') 
+                    for file_type in export_file_types.file_types
+                    ]
+     return pattern_list + new_urls + export_urls
 
 
 for model_name in view_names:

--- a/escalate/core/views/__init__.py
+++ b/escalate/core/views/__init__.py
@@ -2,6 +2,7 @@
 from .login import *
 from .menu import *
 from .crud_views import *
+from .export_views import *
 from .model_tag import *
 from .workflow import *
 from .user_views import *

--- a/escalate/core/views/crud_view_methods/list_methods.py
+++ b/escalate/core/views/crud_view_methods/list_methods.py
@@ -34,11 +34,12 @@ methods = {
     'Material': {
         'model': core.models.view_tables.Material,
         'context_object_name': 'materials',
-        # 'table_columns': ['Chemical Name', 'Abbreviation', 'Status', 'Actions'],
-        'table_columns': ['Status', 'Actions'],
+        'table_columns': ['Chemical Name', 'Consumable', 'Composite', 'Actions'],
+        # 'table_columns': ['Status', 'Actions'],
         'column_necessary_fields': {
-            # 'Chemical Name': ['chemical_name'],
-            # 'Abbreviation': ['abbreviation'],
+            'Chemical Name': ['description'],
+            'Consumable': ['consumable'],
+            'Composite': ['composite_flg'],
             'Status': ['status_description']
         },
         'ordering': ['status_description'],

--- a/escalate/core/views/crud_view_methods/model_view_generic.py
+++ b/escalate/core/views/crud_view_methods/model_view_generic.py
@@ -2,6 +2,7 @@ from django.db.models.query import QuerySet
 from django.db.models import Q
 from django.urls import reverse_lazy, reverse
 from django.http import HttpResponse, HttpResponseRedirect, FileResponse
+from django.views import View
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 # from django.views.generic.edit import FormView, CreateView, DeleteView, UpdateView
@@ -11,6 +12,8 @@ from core.forms.forms import NoteForm, TagSelectForm, UploadEdocForm
 from django.forms import modelformset_factory
 from django.shortcuts import get_object_or_404, render
 from django.core.exceptions import FieldDoesNotExist
+import csv
+import core.views.exports.file_types as export_file_types
 
 # class with generic classes to use in models
 
@@ -138,6 +141,11 @@ class GenericModelList(GenericListView):
         context['table_data'] = table_data
         # get rid of underscores with spaces and capitalize
         context['title'] = model_name.replace('_', ' ').capitalize()
+
+        export_urls = {}
+        for t in export_file_types.file_types:
+            export_urls[t.upper()] = reverse_lazy(f'{model_name}_export_{t}')
+        context['export_urls'] = export_urls
         return context
 
     def post(self, request, *args, **kwargs):
@@ -453,5 +461,63 @@ class GenericModelView(DetailView):
             f'{self.model_name}_update', kwargs={'pk': obj.pk})
         context['detail_data'] = detail_data
         return context
+
+class GenericModelExport(View):
+    model = None
+    file_type = None
+    column_names = None
+    column_necessary_fields = None
+    # A related path that points to the organization this field belongs to
+    org_related_path = None
+
+    def get(self, request, *args, **kwargs):
+        if self.file_type == 'csv':
+            return self.export_csv()
+        else:
+            return HttpResponse('Failed to get requested file')
+
+    def get_queryset(self):
+        if 'current_org_id' in self.request.session:
+            if self.org_related_path:
+                org_filter_kwargs = {self.org_related_path : self.request.session['current_org_id']}
+                base_query = self.model.objects.filter(**org_filter_kwargs)
+            else:
+                try:
+                    #print(self.model._meta.get_fields())
+                    org_field = self.model._meta.get_field('organization')
+                    base_query = self.model.objects.filter(organization=self.request.session['current_org_id'])
+                except FieldDoesNotExist:
+                    base_query = self.model.objects.all()
+        else:
+            base_query = self.model.objects.none()
+        return base_query
+
+    def export_csv(self):
+        response = HttpResponse(content_type="text/csv")
+        model_string_name = self.model.__name__
+        filename = f'{model_string_name.capitalize()}.csv'
+        response['Content-Disposition'] = f'attachment; filename={filename}'
+
+        writer = csv.writer(response)
+        writer.writerow([*self.column_names])
+
+        model_objects = self.get_queryset()
+
+        for obj in model_objects:
+            row = []
+            for col_name in self.column_names:
+                cell_data = ""
+                fields_for_cell = [getattr(obj, field) for field in self.column_necessary_fields[col_name]]
+                for k in range(len(fields_for_cell)):
+                    if fields_for_cell[k] == None:
+                        fields_for_cell[k] = ''
+                    if not isinstance(fields_for_cell[k], str):
+                        fields_for_cell[k] = str(fields_for_cell[k])
+
+                    cell_data = " ".join(fields_for_cell)
+                    cell_data = cell_data.strip()
+                row.append(cell_data)
+            writer.writerow(row)
+        return response
 
 

--- a/escalate/core/views/export_views.py
+++ b/escalate/core/views/export_views.py
@@ -1,0 +1,24 @@
+from django.urls import reverse_lazy
+from django.views import View
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+import core.models
+import core.forms
+from core.views.crud_view_methods.model_view_generic import GenericModelExport
+from core.views.exports import export_methods
+from core.views.exports import file_types as export_file_types
+
+class LoginRequired(LoginRequiredMixin):
+    login_url = '/'
+    redirect_field_name = 'redirect_to'
+
+
+def create_export_view(model_name, methods):
+    for t in export_file_types.file_types:
+        methods['file_type'] = t
+        class_name = f'{model_name}Export{t.capitalize()}'
+        globals()[class_name] = type(class_name,
+                                          tuple([LoginRequired, GenericModelExport]), methods)
+
+for model_name, methods_list in export_methods.methods.items():
+    create_export_view(model_name, methods_list)

--- a/escalate/core/views/exports/export_methods.py
+++ b/escalate/core/views/exports/export_methods.py
@@ -1,0 +1,234 @@
+import core.models 
+
+methods = {
+    'Actor':{
+        'model': core.models.view_tables.Actor,
+        'column_names': [
+            'First Name',
+            'Last Name',
+            'Person Organization',
+            'Organization',
+            'Systemtool',
+            'Status'
+            ],
+        'column_necessary_fields': {
+            'First Name': ['person_first_name'],
+            'Last Name': ['person_last_name'],
+            'Person Organization': ['person_org'],
+            'Organization': ['org_full_name'],
+            'Systemtool': ['systemtool_name'],
+            'Status': ['status_description']
+        }
+    },
+    'Inventory':{
+        'model': core.models.view_tables.Inventory,
+        'column_names': [
+            'Description',
+            'Owner',
+            'Operator',
+            'Lab',
+            'Status'
+            ],
+        'column_necessary_fields': {
+            'Description': ['description'],
+            'Owner': ['owner_description'],
+            'Operator': ['operator_description'],
+            'Lab': ['lab_description'],
+            'Status': ['status_description']
+        }
+    },
+    'Material':{
+        'model': core.models.view_tables.Material,
+        'column_names': [
+            'Chemical Name',
+            'Consumable',
+            'Composite',
+            'Status'
+            ],
+        'column_necessary_fields': {
+            'Chemical Name': ['description'],
+            'Consumable': ['consumable'],
+            'Composite': ['composite_flg'],
+            'Status': ['status_description']
+        }
+    },
+    'Systemtool':{
+        'model': core.models.view_tables.Systemtool,
+        'column_names': [
+            'Name',
+            'Description',
+            'Vendor',
+            'Type',
+            'Model',
+            'Serial',
+            'Version'
+            ],
+        'column_necessary_fields': {
+            'Name': ['systemtool_name'],
+            'Description': ['description'],
+            'Vendor': ['organization_fullname'],
+            'Type': ['systemtool_type_description'],
+            'Model': ['model'],
+            'Serial': ['serial'],
+            'Version': ['ver']
+        }
+    },
+    'MaterialType':{
+        'model': core.models.view_tables.MaterialType,
+        'column_names': [
+            'Description',
+            ],
+        'column_necessary_fields': {
+            'Description': ['description']
+        }
+    },
+    'Organization':{
+        'model': core.models.view_tables.Organization,
+        'column_names': [
+            'Name',
+            'Description',
+            'Address 1',
+            'Address 2',
+            'City',
+            'State/Province',
+            'Zipcode',
+            'Country',
+            'Website',
+            'Phone',
+            'Parent Organization'
+            ],
+        'column_necessary_fields': {
+            'Name': ['full_name'],
+            'Description': ['description'],
+            'Address 1': ['address1'],
+            'Address 2': ['address2'],
+            'City': ['city'],
+            'State/Province': ['state_province'],
+            'Zipcode': ['zip'],
+            'Country': ['country'],
+            'Website': ['website_url'],
+            'Phone': ['phone'],
+            'Parent Organization': ['parent_org_full_name']
+        }
+    },
+    'Person':{
+        'model': core.models.view_tables.Person,
+        'column_names': [
+            'First Name',
+            'Middle Name',
+            'Last Name',
+            'Address 1',
+            'Address 2',
+            'City',
+            'State/Province',
+            'Zipcode',
+            'Country',
+            'Phone',
+            'Email',
+            'Title',
+            'Organization'
+            ],
+        'column_necessary_fields': {
+            'First Name': ['first_name'],
+            'Middle Name': ['middle_name'],
+            'Last Name': ['last_name'],
+            'Address 1': ['address1'],
+            'Address 2': ['address2'],
+            'City': ['city'],
+            'State/Province': ['state_province'],
+            'Zipcode': ['zip'],
+            'Country': ['country'],
+            'Phone': ['phone'],
+            'Email': ['email'],
+            'Title': ['title'],
+            'Organization': ['organization_full_name']
+        }
+    },
+    'Status':{
+        'model': core.models.view_tables.Status,
+        'column_names': [
+            'Description'
+            ],
+        'column_necessary_fields': {
+            'Description': ['description'],
+        }
+    },
+    'SystemtoolType':{
+        'model': core.models.view_tables.SystemtoolType,
+        'column_names': [
+            'Description',
+            ],
+        'column_necessary_fields': {
+            'Description': ['description'],
+        }
+    },
+    'Tag':{
+        'model': core.models.view_tables.Tag,
+        'column_names': [
+            'Display Text',
+            'Description',
+            'Tag Type',
+            'Tag Type Description',
+            ],
+        'column_necessary_fields': {
+            'Display Text': ['display_text'],
+            'Description': ['description'],
+            'Tag Type': ['type'],
+            'Tag Type Description': ['type_description'],
+        }
+    },
+    'TagType':{
+        'model': core.models.view_tables.TagType,
+        'column_names': [
+            'Type',
+            'Description',
+            ],
+        'column_necessary_fields': {
+            'Type': ['type'],
+            'Description': ['description'],
+        }
+    },
+    'UdfDef':{
+        'model': core.models.view_tables.UdfDef,
+        'column_names': [
+            'Description',
+            'Value Type',
+            'Value Type Description',
+            'Unit'
+            ],
+        'column_necessary_fields': {
+            'Description': ['description'],
+            'Value Type': ['val_type'],
+            'Value Type Description': ['val_type_description'],
+            'Unit': ['unit']
+        }
+    },
+    'InventoryMaterial':{
+        'model': core.models.view_tables.InventoryMaterial,
+        'column_names': [
+            'Description',
+            'Inventory',
+            'Material',
+            'Material Consumable',
+            'Material Composite',
+            'Part Number',
+            'On Hand Amount',
+            'Expiration Date',
+            'Location',
+            'Status'
+            ],
+        'column_necessary_fields': {
+            'Description': ['description'],
+            'Inventory': ['inventory_description'],
+            'Material': ['material_description'],
+            'Material Consumable': ['material_consumable'],
+            'Material Composite': ['material_composite_flg'],
+            'Part Number': ['part_no'],
+            'On Hand Amount': ['onhand_amt'],
+            'Expiration Date': ['expiration_date'],
+            'Location': ['location'],
+            'Status': ['status_description']
+        },
+        'org_related_path': 'inventory__lab__organization'
+    }, 
+}

--- a/escalate/core/views/exports/file_types.py
+++ b/escalate/core/views/exports/file_types.py
@@ -1,0 +1,3 @@
+file_types = [
+    'csv'
+    ]


### PR DESCRIPTION
I added an export csv button to each of the lists of data we've exposed. I created a new generic export class that sends a csv file response on GET and added this export url for each of our exposed data models. The download csv button at the top of each list view is a link to the export csv url for that data model. So, when the user clicks the button, they receive the csv. Also the rows in the csv only corresponds to the data that a user is allowed to view based on their credentials. 

The data in the csv for a data model is a superset of the data of the list view of the same data model because I tried to add as many columns as possible to the csv where as the list view only includes a few relevant columns. 