### PR TITLE
fixed duplication of rmi vals in load scripts

### DIFF
--- a/escalate/core/management/commands/load_loadtables.py
+++ b/escalate/core/management/commands/load_loadtables.py
@@ -286,7 +286,7 @@ class Command(BaseCommand):
         # Vals for each default value
         volume_val = {'value': 0, 'unit':'ml', 'type':'num'}
         dead_vol_val = {'value': 4000, 'unit':'uL', 'type':'num'}
-        amount_val = {'value': 0, 'unit':'gm', 'type':'num'}
+        amount_val = {'value': 0, 'unit':'g', 'type':'num'}
         conc_val = {'value': 0, 'unit':'M', 'type':'num'}
         crystal_score_val = {'value': 0, 'unit':'', 'type':'int'}
 
@@ -299,7 +299,7 @@ class Command(BaseCommand):
                                                               'nominal_value': dead_vol_val,
                                                               'actual_value': dead_vol_val
                                                               })
-        default_amount, created = DefaultValues.objects.get_or_create(**{'description':'Zero gm', 
+        default_amount, created = DefaultValues.objects.get_or_create(**{'description':'Zero g', 
                                                               'nominal_value': amount_val,
                                                               'actual_value': amount_val})
         default_conc, created = DefaultValues.objects.get_or_create(**{'description':'Zero M', 
@@ -490,7 +490,7 @@ class Command(BaseCommand):
         # Vals for each default value
         volume_val = {'value': 0, 'unit':'ml', 'type':'num'}
         dead_vol_val = {'value': 4000, 'unit':'uL', 'type':'num'}
-        amount_val = {'value': 0, 'unit':'gm', 'type':'num'}
+        amount_val = {'value': 0, 'unit':'g', 'type':'num'}
         conc_val = {'value': 0, 'unit':'M', 'type':'num'}
         crystal_score_val = {'value': 0, 'unit':'', 'type':'int'}
 
@@ -503,7 +503,7 @@ class Command(BaseCommand):
                                                               'nominal_value': dead_vol_val,
                                                               'actual_value': dead_vol_val
                                                               })
-        default_amount, created = DefaultValues.objects.get_or_create(**{'description':'Zero gm', 
+        default_amount, created = DefaultValues.objects.get_or_create(**{'description':'Zero g', 
                                                               'nominal_value': amount_val,
                                                               'actual_value': amount_val})
         default_conc, created = DefaultValues.objects.get_or_create(**{'description':'Zero M', 


### PR DESCRIPTION
default unit for amount should be "g" not "gm", across all workflows
the inconsistency was causing a duplication of each reagent material instance's "amount" value, in turn causing experiment creation to fail